### PR TITLE
[Payment] remove China-style words in premium-introduction page and fix ecpay not normally to teacher-list page when paid done

### DIFF
--- a/payments/templates/payments/index.html
+++ b/payments/templates/payments/index.html
@@ -12,13 +12,13 @@
     <div
         class="max-w-2xl p-6 mx-auto transition-transform duration-300 transform bg-white rounded-lg shadow-lg hover:scale-125">
         <h1 class="mb-6 text-3xl font-extrabold text-black">
-            解鎖向領域專家 或 編程大神 直接交流的道路!
+            解鎖向領域專家 或 程式大神 直接交流的道路!
         </h1>
         <h2 class="mb-6 leading-relaxed text-gray-700">
             付費升級為 Premium 用戶即可發起線上指導的申請，讓您的學習之路更上一層樓。
             <br>
-            我們深知編程學習在非即時性文字交流時的局限性，透過 TechEcho 的線上互動工具，
-            您可與技術專家即時(文字/語音)通訊來進行高效率的溝通交流，並透過線上白板、共編程式碼等介面釐清相關問題與知識觀念。
+            我們深知程式學習在非即時交流時的局限性，透過 TechEcho 的線上互動工具，
+            您可與技術專家即時通訊來進行高效率的溝通交流，並透過共編程式碼釐清相關問題。
         </h2>
         <h2 class="mb-8 leading-relaxed text-gray-700">
             無論您想提升職場技能、學術成就還是個人興趣，讓 TechEcho 與 技術社群的各方專家給予您學習、解決問題道路上更多的互動成長機會，打開成功的大門！

--- a/payments/views.py
+++ b/payments/views.py
@@ -143,9 +143,7 @@ def ecpay_after_pay(request):
     print(request.user)
     if request.method == "POST":
         messages.success(request, "付款成功")
-        return redirect("payments:ecpay_after_pay")
-    else:
-        return render(request, "teachers/index.html")
+        return redirect("teachers:index")
 
 
 ###  Line-pay use only


### PR DESCRIPTION
1.  移除Premium升級介紹頁面中的"編程"等用語(改成“程式")
2. 將綠界付款後、沒有正常轉導到"專家清單"頁面的問題修正(類似Linepay已修正問題)